### PR TITLE
fix CODEOWNERS rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# All team members will be automatically requested as code reviewers for any non-draft PR
-@angelkbrown
-@anniethewebcoder
-@catbus00
-@dargacode
-@marice-romero
-@msrezaie
-@victoria240
+# All team members will be automatically requested as code reviewers for every non-draft PR
+* @angelkbrown @anniethewebcoder @catbus00 @dargacode @marice-romero @msrezaie @victoria240


### PR DESCRIPTION
### Attached Issue
This PR resolves #47 

## Change Summary
Reviewers aren't being automatically requested as intended.

Need a `*` at the beginning of the line to match all files, then all usernames must also be on that line, to properly assign multiple reviewers