### PR TITLE
Make sure Husky runs the same scripts as our formatting plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "lint-staged": {
     "*.{css,md,json}": [
-      "prettier --write"
+      "npm run format"
     ],
     "*.ts?(x)": [
-      "eslint",
-      "prettier --write"
+      "npm run lint",
+      "npm run format"
     ],
     "package.json": "npx sort-package-json"
   },


### PR DESCRIPTION
### Attached Issue
This PR resolves #43

## Change Summary
- Call `npm run format` and `npm run lint` from `lint-staged`
  - This should make sure code gets formatted on commit even if the dev's IDE doesn't have Prettier and ESlint configured to run on file save. 
  - It didn't work previously for ESlint, because the old command didn't include `--fix`
