### PR TITLE
76 add Group and Event page component stubs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import Footer from "@components/HomePage/Footer";
 import HomePage from "@components/HomePage/HomePage";
 import NavBar from "@components/HomePage/NavBar";
 import ActivitiesListContainer from "@containers/ActivitiesContainer";
+import EventContainer from "@containers/EventContainer";
+import GroupContainer from "@containers/GroupContainer";
 import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
 
 import styles from "./App.module.css";
@@ -42,6 +44,10 @@ const App = () => {
         <Route path="/activities" Component={ActivitiesListContainer} />
         <Route path="/signup" element={<AccountCreationContainer />} />
         <Route path="/about" element={<AboutPage />} />
+        {/*TODO needs real path with group id */}
+        <Route path="/group" Component={GroupContainer} />
+        {/* TODO needs real path with group and event ids */}
+        <Route path="/event" Component={EventContainer} />
         <Route
           path="/account"
           element={<AuthenticatedContent name={""} email={""} />}

--- a/src/components/EventView/EventView.tsx
+++ b/src/components/EventView/EventView.tsx
@@ -1,0 +1,16 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+import EventVotingWindow from "@components/EventVotingWindow/EventVotingWindow";
+import VotableActivitiesList from "@components/VotableActivitiesList/VotableActivitiesList";
+
+export default function EventView() {
+  return (
+    <div>
+      <h3>EventView</h3>
+      <p>event details here</p>
+      <EventVotingWindow />
+      <VotableActivitiesList />
+    </div>
+  );
+}

--- a/src/components/EventVotingWindow/EventVotingWindow.tsx
+++ b/src/components/EventVotingWindow/EventVotingWindow.tsx
@@ -1,0 +1,11 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+export default function EventVotingWindow() {
+  return (
+    <div>
+      <h4>EventVotingWindow</h4>
+      <p>Shows vote timer progress/completion</p>
+    </div>
+  );
+}

--- a/src/components/EventsList/EventsList.tsx
+++ b/src/components/EventsList/EventsList.tsx
@@ -1,0 +1,18 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+import EventsListItem from "@components/EventsList/EventsListItem";
+
+export default function EventsList() {
+  return (
+    <div>
+      <h4>EventsList</h4>
+      <p>Displays Groups&apos;s Events</p>
+      {/* use a mapped array here */}
+      <EventsListItem />
+      <EventsListItem />
+      <EventsListItem />
+      <EventsListItem />
+    </div>
+  );
+}

--- a/src/components/EventsList/EventsListItem.tsx
+++ b/src/components/EventsList/EventsListItem.tsx
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+import { Link } from "react-router-dom";
+
+export default function EventsListItem() {
+  return (
+    <div>
+      <h5>EventsListItem</h5>
+      <p>Event summary</p>
+      <Link to={"/event"}>View Event</Link>
+    </div>
+  );
+}

--- a/src/components/GroupView/GroupView.tsx
+++ b/src/components/GroupView/GroupView.tsx
@@ -1,0 +1,18 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+import EventsList from "@components/EventsList/EventsList";
+import MembersList from "@components/MembersList/MembersList";
+
+export default function GroupView() {
+  return (
+    <div>
+      <h3>GroupView</h3>
+      <p>group details here</p>
+      <p>join/leave button</p>
+      <MembersList />
+      <EventsList />
+      <p>delete group button</p>
+    </div>
+  );
+}

--- a/src/components/Logout/Logout.tsx
+++ b/src/components/Logout/Logout.tsx
@@ -1,0 +1,11 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+export default function Logout() {
+  return (
+    <div>
+      <h2>Logout</h2>
+      <p>Logs user out of site, redirects to `/signin`</p>
+    </div>
+  );
+}

--- a/src/components/MembersList/MembersList.tsx
+++ b/src/components/MembersList/MembersList.tsx
@@ -1,0 +1,18 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+import MembersListItem from "@components/MembersList/MembersListItem";
+
+export default function MembersList() {
+  return (
+    <div>
+      <h4>MembersList</h4>
+      <p>Displays Groups&apos;s Members</p>
+      {/* use a mapped array here */}
+      <MembersListItem />
+      <MembersListItem />
+      <MembersListItem />
+      <MembersListItem />
+    </div>
+  );
+}

--- a/src/components/MembersList/MembersListItem.tsx
+++ b/src/components/MembersList/MembersListItem.tsx
@@ -1,0 +1,11 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+export default function MembersListItem() {
+  return (
+    <div>
+      <h5>MembersListItem</h5>
+      <p>User summary</p>
+    </div>
+  );
+}

--- a/src/components/VotableActivitiesList/VotableActivitiesList.tsx
+++ b/src/components/VotableActivitiesList/VotableActivitiesList.tsx
@@ -1,0 +1,18 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+import VotableActivitiesListItem from "@components/VotableActivitiesList/VotableActivitiesListItem";
+
+export default function VotableActivitiesList() {
+  return (
+    <div>
+      <h4>VotableActivitiesList</h4>
+      <p>Displays Event&apos;s activities for voting</p>
+      {/* use a mapped array here */}
+      <VotableActivitiesListItem />
+      <VotableActivitiesListItem />
+      <VotableActivitiesListItem />
+      <VotableActivitiesListItem />
+    </div>
+  );
+}

--- a/src/components/VotableActivitiesList/VotableActivitiesListItem.tsx
+++ b/src/components/VotableActivitiesList/VotableActivitiesListItem.tsx
@@ -1,0 +1,11 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+export default function VotableActivitiesListItem() {
+  return (
+    <div>
+      <h5>VotableActivitiesListItem</h5>
+      <p>Activity which allows voting</p>
+    </div>
+  );
+}

--- a/src/containers/EventContainer.tsx
+++ b/src/containers/EventContainer.tsx
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+import EventView from "@components/EventView/EventView";
+
+export default function EventContainer() {
+  return (
+    <div>
+      <h2>EventContainer</h2>
+      <p>Only makes requests and renders EventView</p>
+      <EventView />
+    </div>
+  );
+}

--- a/src/containers/GroupContainer.tsx
+++ b/src/containers/GroupContainer.tsx
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+import GroupView from "@components/GroupView/GroupView";
+
+export default function GroupContainer() {
+  return (
+    <div>
+      <h2>GroupContainer</h2>
+      <p>Only makes requests and renders GroupView</p>
+      <GroupView />
+    </div>
+  );
+}


### PR DESCRIPTION
### Attached Issue

This PR resolves #76

## Change Summary

Visit `/group` and `/event` (Itemporary paths) to see the component trees from each page's container down to the list items:

<img width="405" alt="Screen Shot 2023-12-17 at 11 25 46 AM" src="https://github.com/Code-the-Dream-School/ee-prac-team2-front/assets/12771651/95786735-f2df-4886-aba6-80122447fa3b">
<img width="405" alt="Screen Shot 2023-12-17 at 11 26 01 AM" src="https://github.com/Code-the-Dream-School/ee-prac-team2-front/assets/12771651/1f4bbceb-0bdf-4378-8a9b-5eb8a93240ee">

