### PR TITLE
process ONLY staged files with `lint-staged`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,17 @@
     "typecheck": "tsc --noEmit"
   },
   "lint-staged": {
-    "*.{css,md,json}": [
-      "npm run format"
+    "*": [
+      "prettier --ignore-unknown --write"
     ],
-    "*.ts?(x)": [
-      "npm run lint",
-      "npm run format"
+    "*.{ts, tsx, js,jsx}": [
+      "prettier --write",
+      "eslint --fix"
     ],
-    "package.json": "npx sort-package-json"
+    "package.json": [
+      "prettier --write",
+      "npx sort-package-json"
+    ]
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",


### PR DESCRIPTION
### Attached Issue
This PR resolves #98 

## Change Summary
The point of `lint-fixed` is that it'll run the specified script on only the staged files. When I ran `npm run lint` and `npm run format` inside of it, I forced it to process every file in the repo before every single commit. 

(I can't test this until it's merged but if it looks good I'll fix on the BE repo too)